### PR TITLE
feat: parallelized per contributor

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,0 +1,9 @@
+import * as github from "@actions/github";
+
+import { Octokit } from "./types.js";
+
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+export const githubToken = process.env.GITHUB_TOKEN!;
+
+export const { repo: locator } = github.context;
+export const octokit: Octokit = github.getOctokit(githubToken);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { expect, test, vi } from "vitest";
 
 vi.mock("all-contributors-for-repository", () => ({
 	getAllContributorsForRepository: () => ({
@@ -60,81 +60,79 @@ vi.mock("@actions/github", () => ({
 	getOctokit: () => mockOctokit,
 }));
 
-describe("end-to-end", () => {
-	test("getAllContributorsForRepository", async () => {
-		process.env.GITHUB_TOKEN = "gh_abc123";
-		process.env.GITHUB_REPOSITORY = mockRepo;
+test("end-to-end", async () => {
+	process.env.GITHUB_TOKEN = "gh_abc123";
+	process.env.GITHUB_REPOSITORY = mockRepo;
 
-		await import("./index.js");
+	await import("./index.js");
 
-		expect(mockRequest.mock.calls).toMatchInlineSnapshot(`
-			[
-			  [
-			    "GET /repos/{owner}/{repo}/contents/{path}",
-			    {
-			      "headers": {
-			        "X-GitHub-Api-Version": "2022-11-28",
-			      },
-			      "owner": "Mock-Owner",
-			      "path": ".all-contributorsrc",
-			      "repo": "test-repository",
-			    },
-			  ],
-			  [
-			    "GET /repos/{owner}/{repo}/issues/{issue_number}/comments",
-			    {
-			      "headers": {
-			        "X-GitHub-Api-Version": "2022-11-28",
-			      },
-			      "issue_number": 111,
-			      "owner": "Mock-Owner",
-			      "repo": "test-repository",
-			    },
-			  ],
-			  [
-			    "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
-			    {
-			      "body": "@all-contributors please add @Existing-Login for feat.
+	expect(mockRequest.mock.calls).toMatchInlineSnapshot(`
+		[
+		  [
+		    "GET /repos/{owner}/{repo}/contents/{path}",
+		    {
+		      "headers": {
+		        "X-GitHub-Api-Version": "2022-11-28",
+		      },
+		      "owner": "Mock-Owner",
+		      "path": ".all-contributorsrc",
+		      "repo": "test-repository",
+		    },
+		  ],
+		  [
+		    "GET /repos/{owner}/{repo}/issues/{issue_number}/comments",
+		    {
+		      "headers": {
+		        "X-GitHub-Api-Version": "2022-11-28",
+		      },
+		      "issue_number": 111,
+		      "owner": "Mock-Owner",
+		      "repo": "test-repository",
+		    },
+		  ],
+		  [
+		    "GET /repos/{owner}/{repo}/issues/{issue_number}/comments",
+		    {
+		      "headers": {
+		        "X-GitHub-Api-Version": "2022-11-28",
+		      },
+		      "issue_number": 222,
+		      "owner": "Mock-Owner",
+		      "repo": "test-repository",
+		    },
+		  ],
+		  [
+		    "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
+		    {
+		      "body": "@all-contributors please add @Existing-Login for feat.
 
-			> 🤖 Beep boop! This comment was added automatically by [all-contributors-auto-action](https://github.com/marketplace/actions/all-contributors-auto-action).
-			> Not all contributions can be detected from Git & GitHub alone. Please comment any missing contribution types this bot missed.
-			> ...and of course, thank you for contributing! 💙",
-			      "headers": {
-			        "X-GitHub-Api-Version": "2022-11-28",
-			      },
-			      "issue_number": 111,
-			      "owner": "Mock-Owner",
-			      "repo": "test-repository",
-			    },
-			  ],
-			  [
-			    "GET /repos/{owner}/{repo}/issues/{issue_number}/comments",
-			    {
-			      "headers": {
-			        "X-GitHub-Api-Version": "2022-11-28",
-			      },
-			      "issue_number": 222,
-			      "owner": "Mock-Owner",
-			      "repo": "test-repository",
-			    },
-			  ],
-			  [
-			    "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
-			    {
-			      "body": "@all-contributors please add @New-Login for ideas.
+		> 🤖 Beep boop! This comment was added automatically by [all-contributors-auto-action](https://github.com/marketplace/actions/all-contributors-auto-action).
+		> Not all contributions can be detected from Git & GitHub alone. Please comment any missing contribution types this bot missed.
+		> ...and of course, thank you for contributing! 💙",
+		      "headers": {
+		        "X-GitHub-Api-Version": "2022-11-28",
+		      },
+		      "issue_number": 111,
+		      "owner": "Mock-Owner",
+		      "repo": "test-repository",
+		    },
+		  ],
+		  [
+		    "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
+		    {
+		      "body": "@all-contributors please add @New-Login for ideas.
 
-			> 🤖 Beep boop! This comment was added automatically by [all-contributors-auto-action](https://github.com/marketplace/actions/all-contributors-auto-action).
-			> Not all contributions can be detected from Git & GitHub alone. Please comment any missing contribution types this bot missed.
-			> ...and of course, thank you for contributing! 💙",
-			      "headers": {
-			        "X-GitHub-Api-Version": "2022-11-28",
-			      },
-			      "issue_number": 222,
-			      "owner": "Mock-Owner",
-			      "repo": "test-repository",
-			    },
-			  ],
-			]
-		`);
-	});
+		> 🤖 Beep boop! This comment was added automatically by [all-contributors-auto-action](https://github.com/marketplace/actions/all-contributors-auto-action).
+		> Not all contributions can be detected from Git & GitHub alone. Please comment any missing contribution types this bot missed.
+		> ...and of course, thank you for contributing! 💙",
+		      "headers": {
+		        "X-GitHub-Api-Version": "2022-11-28",
+		      },
+		      "issue_number": 222,
+		      "owner": "Mock-Owner",
+		      "repo": "test-repository",
+		    },
+		  ],
+		]
+	`);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,11 @@
 import * as core from "@actions/core";
-import * as github from "@actions/github";
 import { getAllContributorsForRepository } from "all-contributors-for-repository";
 
-import { commentDisclaimer, commentPrefix } from "./comments.js";
-import { doesPullAlreadyHaveComment } from "./doesPullAlreadyHaveComment.js";
+import { githubToken, locator, octokit } from "./context.js";
 import { getExistingContributors } from "./getExistingContributors.js";
-import { getMissingContributions } from "./getMissingContributions.js";
+import { postContributorComments } from "./postContributorComments.js";
 
 core.debug("About to retrieve contributors...");
-
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-const githubToken = process.env.GITHUB_TOKEN!;
-
-const { repo: locator } = github.context;
-const octokit = github.getOctokit(githubToken);
 
 const contributors = await getAllContributorsForRepository({
 	auth: githubToken,
@@ -24,67 +16,12 @@ core.debug(`Retrieved contributors: ${JSON.stringify(contributors)}`);
 
 const existingContributors = await getExistingContributors(octokit, locator);
 
-for (const [contributor, contributions] of Object.entries(contributors)) {
-	core.debug(
-		`Retrieving missing contributions for contributor: ${contributor}`,
-	);
-
-	const missingContributions = getMissingContributions(
-		contributor,
-		contributions,
-		existingContributors,
-	);
-	if (!Object.keys(missingContributions).length) {
-		core.debug(`${contributor} is not missing any contributions.`);
-		continue;
-	}
-
-	core.debug(
-		`${contributor} is missing: ${JSON.stringify(missingContributions)}`,
-	);
-
-	for (const [type, ids] of Object.entries(missingContributions)) {
-		const latestId = ids[ids.length - 1];
-
-		core.debug(`Checking for existing ${contributor} comment: ${latestId}`);
-
-		const existingComment = await doesPullAlreadyHaveComment(
-			octokit,
-			locator,
-			latestId,
+await Promise.all(
+	Object.entries(contributors).map(async ([contributor, contributions]) => {
+		await postContributorComments(
+			contributor,
+			contributions,
+			existingContributors,
 		);
-		if (existingComment) {
-			core.debug(`${latestId} already has a comment: ${existingComment.id}`);
-			continue;
-		}
-
-		core.debug(
-			`${latestId} doesn't already have a comment; posting a new one.`,
-		);
-
-		const commentRequestArgs = [
-			"POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
-			{
-				...locator,
-				body: [
-					`${commentPrefix} @${contributor} for ${type}.`,
-					commentDisclaimer,
-				].join("\n\n"),
-				headers: {
-					"X-GitHub-Api-Version": "2022-11-28",
-				},
-				issue_number: latestId,
-			},
-		] as const;
-
-		if (process.env.LOCAL_TESTING === "true") {
-			core.debug(`LOCAL_TESTING: ${JSON.stringify(commentRequestArgs)}`);
-		} else {
-			// TODO: It'd be nice to deduplicate these comments.
-			// PRs that include multiple types will cause multiple comments...
-			// https://github.com/JoshuaKGoldberg/all-contributors-auto-action/issues/180
-			const newComment = await octokit.request(...commentRequestArgs);
-			core.debug(`Posted comment ${newComment.data.id} for ${latestId}.`);
-		}
-	}
-}
+	}),
+);

--- a/src/postContributionComment.test.ts
+++ b/src/postContributionComment.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { postContributionComment } from "./postContributionComment.js";
+
+const mockDebug = vi.fn();
+
+vi.mock("@actions/core", () => ({
+	get debug() {
+		return mockDebug;
+	},
+}));
+
+const mockDoesPullAlreadyHaveComment = vi.fn();
+
+vi.mock("./doesPullAlreadyHaveComment.js", () => ({
+	get doesPullAlreadyHaveComment() {
+		return mockDoesPullAlreadyHaveComment;
+	},
+}));
+
+const mockRequest = vi.fn(() => ({
+	data: { id: 111 },
+}));
+
+vi.mock("./context.js", () => ({
+	locator: {},
+	get octokit() {
+		return {
+			request: mockRequest,
+		};
+	},
+}));
+
+const contributor = "Test-Contributor";
+
+describe("postContributionComment", () => {
+	it("doesn't post a comment when it already exists", async () => {
+		mockDoesPullAlreadyHaveComment.mockResolvedValueOnce({});
+
+		await postContributionComment(contributor, 222, "fix");
+
+		expect(mockRequest).not.toHaveBeenCalled();
+		expect(mockDebug.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    "Checking for existing Test-Contributor comment: 222",
+			  ],
+			  [
+			    "222 already has a comment: undefined",
+			  ],
+			]
+		`);
+	});
+
+	it("logs to core.debug without posting a comment when the comment doesn't yet exist and LOCAL_TESTING is enabled", async () => {
+		mockDoesPullAlreadyHaveComment.mockResolvedValueOnce(undefined);
+		process.env.LOCAL_TESTING = "true";
+
+		await postContributionComment(contributor, 222, "fix");
+
+		expect(mockRequest).not.toHaveBeenCalled();
+		expect(mockDebug.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    "Checking for existing Test-Contributor comment: 222",
+			  ],
+			  [
+			    "222 doesn't already have a comment; posting a new one.",
+			  ],
+			  [
+			    "LOCAL_TESTING: ["POST /repos/{owner}/{repo}/issues/{issue_number}/comments",{"body":"@all-contributors please add @Test-Contributor for fix.\\n\\n> 🤖 Beep boop! This comment was added automatically by [all-contributors-auto-action](https://github.com/marketplace/actions/all-contributors-auto-action).\\n> Not all contributions can be detected from Git & GitHub alone. Please comment any missing contribution types this bot missed.\\n> ...and of course, thank you for contributing! 💙","headers":{"X-GitHub-Api-Version":"2022-11-28"},"issue_number":222}]",
+			  ],
+			]
+		`);
+	});
+
+	it("logs to core.debug and posts a comment when the comment doesn't yet exist and LOCAL_TESTING is not enabled", async () => {
+		mockDoesPullAlreadyHaveComment.mockResolvedValueOnce(undefined);
+		process.env.LOCAL_TESTING = "false";
+
+		await postContributionComment(contributor, 222, "fix");
+
+		expect(mockRequest.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
+			    {
+			      "body": "@all-contributors please add @Test-Contributor for fix.
+
+			> 🤖 Beep boop! This comment was added automatically by [all-contributors-auto-action](https://github.com/marketplace/actions/all-contributors-auto-action).
+			> Not all contributions can be detected from Git & GitHub alone. Please comment any missing contribution types this bot missed.
+			> ...and of course, thank you for contributing! 💙",
+			      "headers": {
+			        "X-GitHub-Api-Version": "2022-11-28",
+			      },
+			      "issue_number": 222,
+			    },
+			  ],
+			]
+		`);
+		expect(mockDebug.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    "Checking for existing Test-Contributor comment: 222",
+			  ],
+			  [
+			    "222 doesn't already have a comment; posting a new one.",
+			  ],
+			  [
+			    "Posted comment 111 for 222.",
+			  ],
+			]
+		`);
+	});
+});

--- a/src/postContributionComment.ts
+++ b/src/postContributionComment.ts
@@ -1,0 +1,50 @@
+import * as core from "@actions/core";
+
+import { commentDisclaimer, commentPrefix } from "./comments.js";
+import { locator, octokit } from "./context.js";
+import { doesPullAlreadyHaveComment } from "./doesPullAlreadyHaveComment.js";
+
+export async function postContributionComment(
+	contributor: string,
+	latestId: number,
+	type: string,
+) {
+	core.debug(`Checking for existing ${contributor} comment: ${latestId}`);
+
+	const existingComment = await doesPullAlreadyHaveComment(
+		octokit,
+		locator,
+		latestId,
+	);
+	if (existingComment) {
+		core.debug(`${latestId} already has a comment: ${existingComment.id}`);
+		return;
+	}
+
+	core.debug(`${latestId} doesn't already have a comment; posting a new one.`);
+
+	const commentRequestArgs = [
+		"POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
+		{
+			...locator,
+			body: [
+				`${commentPrefix} @${contributor} for ${type}.`,
+				commentDisclaimer,
+			].join("\n\n"),
+			headers: {
+				"X-GitHub-Api-Version": "2022-11-28",
+			},
+			issue_number: latestId,
+		},
+	] as const;
+
+	if (process.env.LOCAL_TESTING === "true") {
+		core.debug(`LOCAL_TESTING: ${JSON.stringify(commentRequestArgs)}`);
+	} else {
+		// TODO: It'd be nice to deduplicate these comments.
+		// PRs that include multiple types will cause multiple comments...
+		// https://github.com/JoshuaKGoldberg/all-contributors-auto-action/issues/180
+		const newComment = await octokit.request(...commentRequestArgs);
+		core.debug(`Posted comment ${newComment.data.id} for ${latestId}.`);
+	}
+}

--- a/src/postContributorComments.test.ts
+++ b/src/postContributorComments.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { postContributorComments } from "./postContributorComments.js";
+
+vi.mock("@actions/core");
+
+const mockPostContributionComment = vi.fn();
+
+vi.mock("./postContributionComment.js", () => ({
+	get postContributionComment() {
+		return mockPostContributionComment;
+	},
+}));
+
+const contributor = "Test-Contributor";
+
+describe("postContributorComments", () => {
+	it("doesn't post comments when the contributor is not missing any contributions", async () => {
+		await postContributorComments(contributor, {}, {});
+
+		expect(mockPostContributionComment).not.toHaveBeenCalled();
+	});
+
+	it("post a comment for each missing contribution when they exist", async () => {
+		const contribution = 111;
+		await postContributorComments(
+			contributor,
+			{
+				fix: [contribution],
+			},
+			{},
+		);
+
+		expect(mockPostContributionComment).toHaveBeenCalledWith(
+			contributor,
+			contribution,
+			"fix",
+		);
+	});
+});

--- a/src/postContributorComments.ts
+++ b/src/postContributorComments.ts
@@ -1,0 +1,34 @@
+import * as core from "@actions/core";
+import { ContributorContributions } from "all-contributors-for-repository";
+
+import { ExistingContributions } from "./getExistingContributors.js";
+import { getMissingContributions } from "./getMissingContributions.js";
+import { postContributionComment } from "./postContributionComment.js";
+
+export async function postContributorComments(
+	contributor: string,
+	contributions: ContributorContributions,
+	existingContributors: ExistingContributions,
+) {
+	core.debug(
+		`Retrieving missing contributions for contributor: ${contributor}`,
+	);
+
+	const missingContributions = getMissingContributions(
+		contributor,
+		contributions,
+		existingContributors,
+	);
+	if (!Object.keys(missingContributions).length) {
+		core.debug(`${contributor} is not missing any contributions.`);
+		return;
+	}
+
+	core.debug(
+		`${contributor} is missing: ${JSON.stringify(missingContributions)}`,
+	);
+
+	for (const [type, ids] of Object.entries(missingContributions)) {
+		await postContributionComment(contributor, ids[ids.length - 1], type);
+	}
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #185; fixes #186
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/all-contributors-auto-action/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/all-contributors-auto-action/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Splits off a `postContributorComments` function out of the body of the loop in `src/index.ts`. Also splits out a `postContributionComment` within that. Both new functions are directly unit tested.